### PR TITLE
Feature/isleader

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,11 @@ Usage of SLALite:
 * `clear_on_boot` (default: `false`). Sets if the database is cleared on
   startup (useful for tests).
 
+*MF2C settings*
+
+* `policies` (default: `https://localhost:46050/api`). Sets the location of the Policies component.
+* `isleader` (default: ""). If not empty, this setting, interpreted as a boolean, is used to check if the SLALite is running on a leader or not.
+
 #### Env vars  ####
 
 Every file setting can be overriden with the use of environment variables.

--- a/assessment/mf2c.go
+++ b/assessment/mf2c.go
@@ -31,8 +31,17 @@ This file contains the mF2C asssessment code
 
 // AssessMf2cAgreements is the main process for the mf2c assessment
 func AssessMf2cAgreements(repo model.IRepository, mf2cRepo cimi.IRepository,
-	ma monitor.MonitoringAdapter, policies mf2c.Policies) {
+	ma monitor.MonitoringAdapter, policies mf2c.PoliciesConnecter) {
 
+	// Checking if running on the leader
+	leader, err := policies.IsLeader()
+	if err != nil {
+		log.Printf("Error connecting to Policies component (%v). Skipping assessment...", err)
+		return
+	} else if !leader {
+		log.Printf("Not running on leader. Exiting...")
+		return
+	}
 	agreements, err := repo.GetAllAgreements()
 	log.Printf("Running assessment. Processing %d agreement(s)", len(agreements))
 	if err != nil {

--- a/assessment/mf2c.go
+++ b/assessment/mf2c.go
@@ -18,6 +18,7 @@ package assessment
 
 import (
 	"SLALite/assessment/monitor"
+	"SLALite/mf2c"
 	"SLALite/model"
 	"SLALite/repositories/cimi"
 	"log"
@@ -29,7 +30,9 @@ This file contains the mF2C asssessment code
 */
 
 // AssessMf2cAgreements is the main process for the mf2c assessment
-func AssessMf2cAgreements(repo model.IRepository, mf2cRepo cimi.IRepository, ma monitor.MonitoringAdapter) {
+func AssessMf2cAgreements(repo model.IRepository, mf2cRepo cimi.IRepository,
+	ma monitor.MonitoringAdapter, policies mf2c.Policies) {
+
 	agreements, err := repo.GetAllAgreements()
 	log.Printf("Running assessment. Processing %d agreement(s)", len(agreements))
 	if err != nil {

--- a/docker/slalite_cimi.yml
+++ b/docker/slalite_cimi.yml
@@ -6,4 +6,6 @@ cimipwd: super ADMIN
 cimiinsecure: true
 cimiurl: https://proxy:443/api
 
+policies: http://policies:46050/api
+
 port: 46030

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ import (
 )
 
 var cimirepo cimi.Repository
-var policies *mf2c.Policies
+var policies mf2c.PoliciesConnecter
 
 // version and date are defined on compilation (see makefile)
 var version string

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"SLALite/assessment/monitor"
 	"SLALite/assessment/monitor/cimiadapter"
 	"SLALite/assessment/notifier"
+	"SLALite/mf2c"
 	"SLALite/model"
 	"SLALite/repositories/cimi"
 	"SLALite/repositories/memrepository"
@@ -37,6 +38,7 @@ import (
 )
 
 var cimirepo cimi.Repository
+var policies *mf2c.Policies
 
 // version and date are defined on compilation (see makefile)
 var version string
@@ -79,6 +81,12 @@ func main() {
 
 	if errRepo != nil {
 		log.Fatal("Error creating repository: ", errRepo.Error())
+	}
+
+	var err error
+	policies, err = mf2c.NewPolicies(config)
+	if err != nil {
+		log.Fatal("Error creating Policies: ", err.Error())
 	}
 
 	repo, _ = validation.New(repo, true)
@@ -161,5 +169,5 @@ func validateProviders(repo model.IRepository) {
 
 func assessMf2cAgreements(repo model.IRepository) {
 	ma := cimiadapter.New(cimirepo)
-	assessment.AssessMf2cAgreements(repo, cimirepo, ma)
+	assessment.AssessMf2cAgreements(repo, cimirepo, ma, policies)
 }

--- a/mf2c/policies.go
+++ b/mf2c/policies.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2019 Atos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mf2c contains code to connect to rest of components of the mF2C stack
+package mf2c
+
+import (
+	"SLALite/utils/rest"
+	"errors"
+	"fmt"
+	"log"
+	"net/url"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	urlProp           = "policies"
+	defaultURL string = "https://localhost:46050/api"
+
+	pathIsLeader = "v1/resource-management/policies/leaderinfo"
+)
+
+// Policies is the struct to connect to a Policies component
+type Policies struct {
+	client *rest.Client
+}
+
+type isLeader struct {
+	ImBackup bool `json:"imBackup"`
+	ImLeader bool `json:"imLeader"`
+}
+
+// NewPolicies returns a Policies component client
+func NewPolicies(config *viper.Viper) (*Policies, error) {
+	if config == nil {
+		return nil, errors.New("Must provide config to mf2c.policies.NewPolicies()")
+	}
+	setDefaults(config)
+	logConfig(config)
+
+	baseurl := config.GetString(urlProp)
+
+	url, err := url.Parse(baseurl)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("URL=%#v", url)
+	policies := Policies{
+		client: rest.New(url, nil),
+	}
+	return &policies, nil
+}
+
+func setDefaults(config *viper.Viper) {
+	config.SetDefault(urlProp, defaultURL)
+}
+
+func logConfig(config *viper.Viper) {
+	log.Printf("Policies configuration\n"+
+		"\tURL: %v\n",
+		config.GetString(urlProp))
+}
+
+// IsLeader returns if the current agent is leader or not
+func (o Policies) IsLeader() (bool, error) {
+	target := new(isLeader)
+	err := o.client.Get(pathIsLeader, &target)
+	if err != nil {
+		return false, err
+	}
+	return target.ImLeader, nil
+}

--- a/mf2c/policies_test.go
+++ b/mf2c/policies_test.go
@@ -61,7 +61,7 @@ func createPolicies(policiesURL string) (Policies, error) {
 	config.SetEnvPrefix(utils.ConfigPrefix) // Env vars start with 'SLA_'
 	config.Set(urlProp, policiesURL)
 	config.AutomaticEnv()
-	policies, err := NewPolicies(config)
+	policies, err := NewPoliciesClient(config)
 	return *policies, err
 }
 

--- a/mf2c/policies_test.go
+++ b/mf2c/policies_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 Atos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This tests access to Policies component.
+
+To run this test, set up a policies component and set env var SLA_POLICIES=<url>
+(e.g. SLA_POLICIES=https://localhost:46050/api)
+*/
+
+package mf2c
+
+import (
+	"SLALite/utils"
+	"os"
+	"testing"
+
+	"github.com/spf13/viper"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var policies Policies
+
+func TestMain(m *testing.M) {
+	var err error
+	var ok bool
+	var policiesURL string
+	result := -1
+
+	if policiesURL, ok = os.LookupEnv("SLA_POLICIES"); !ok {
+		log.Info("Skipping Policies integration test")
+		os.Exit(0)
+	}
+
+	if policies, err = createPolicies(policiesURL); err != nil {
+		log.Fatalf("Error creating repository: %s", err.Error())
+	}
+
+	result = m.Run()
+
+	os.Exit(result)
+}
+
+func createPolicies(policiesURL string) (Policies, error) {
+
+	config := viper.New()
+	config.SetEnvPrefix(utils.ConfigPrefix) // Env vars start with 'SLA_'
+	config.Set(urlProp, policiesURL)
+	config.AutomaticEnv()
+	policies, err := NewPolicies(config)
+	return *policies, err
+}
+
+func TestIsLeader(t *testing.T) {
+	result, err := policies.IsLeader()
+	if err != nil {
+		t.Errorf("Error getting leader: %#v", err)
+	}
+	log.Debugf("Policies.IsLeader = %v", result)
+}

--- a/utils/rest/rest.go
+++ b/utils/rest/rest.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2019 Atos
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+)
+
+// Method is the type for allowed REST verbs
+type Method string
+
+// Path is the type for REST subpaths from the base URL
+type Path string
+
+const (
+	// POST method
+	POST = "POST"
+	// GET method
+	GET = "GET"
+	// PUT method
+	PUT = "PUT"
+	// DELETE method
+	DELETE = "DELETE"
+)
+
+// Error represents REST errors raised when requests return 4xx or 5xx code
+type Error struct {
+	Code    int
+	Message string
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("%d: %s", e.Code, e.Message)
+}
+
+/*
+Client is a type to build a basic REST client.
+
+It is intended to be used for application/json content type requests.
+
+The struct contains a base URL and an http.Client. It can be built directly
+or using NewRestClient. The former allows passing a nil http.Client so the
+RestClient is initialized with a default http.Client.
+
+Request methods (Request, Post, Get...) return errors on fail.
+
+* Requests with 4xx or 5xx status are return as Error type
+
+* Other errors coming from http.Client or serialization may be returned
+
+	url := &url.URL{Path: baseurl}
+	client := rest.New(url, nil)
+*/
+type Client struct {
+	BaseURL *url.URL
+	Client  *http.Client
+}
+
+/*
+New builds a REST client.
+
+If httpClient is nil, it is intialized with a default http.Client.
+Provide httpClient to support cookies, additional TLS configuration...
+*/
+func New(baseurl *url.URL, httpClient *http.Client) *Client {
+	return &Client{
+		BaseURL: baseurl,
+		Client:  buildHTTPClient(httpClient),
+	}
+}
+
+/*
+Request makes a REST request to the URL derived from the BaseURL and the subpath 'path',
+using the 'method' verb.
+
+The content parameter is passed as the request body, and will be sent with
+application/json content-type. The response body will be parsed as JSON and returned in target.
+*/
+func (r *Client) Request(method Method, subpath Path, content interface{}, target interface{}) error {
+
+	var err error
+	var resp *http.Response
+	var jsonValue []byte
+	var reader io.Reader
+
+	if content != nil {
+		jsonValue, err = json.Marshal(content)
+		if err != nil {
+			return err
+		}
+		reader = bytes.NewBuffer(jsonValue)
+	}
+
+	/*
+	 * ResolveReference should be used to calculate the derived url, but
+	 * if BaseURL specifies a directory, the directory is discarded
+	 * (i.e. ResolveReference("http://host/api", "users") -> "http://host/users")
+	 *
+	 * This is why path.Join is used (which is somehow dangerous)
+	 */
+
+	//url := r.BaseURL.ResolveReference(&url.URL{Path: string(subpath)})
+	url := *r.BaseURL
+	url.Path = path.Join(r.BaseURL.Path, string(subpath))
+	fmt.Printf("URL=%#v", url)
+	req, _ := http.NewRequest(string(method), url.String(), reader)
+	if reader != nil {
+		req.Header.Set("Content-type", "application/json")
+	}
+	resp, err = r.Client.Do(req)
+
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 404 {
+		return Error{404, fmt.Sprintf("Path '%s' not found", subpath)}
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		return Error{resp.StatusCode, string(body)}
+	}
+
+	if target != nil {
+		err = json.NewDecoder(resp.Body).Decode(target)
+	}
+
+	return err
+}
+
+// Get makes a GET request. See Request.
+func (r *Client) Get(resource Path, target interface{}) error {
+
+	err := r.Request(GET, resource, nil, target)
+
+	return err
+}
+
+// Post makes a POST request. See Request.
+func (r *Client) Post(resource Path, entity interface{}, target interface{}) error {
+
+	err := r.Request(POST, resource, entity, target)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Put makes a PUT request. See Request.
+func (r *Client) Put(resource Path, entity interface{}) error {
+
+	err := r.Request(PUT, resource, entity, nil)
+
+	return err
+}
+
+// Delete makes a DELETE request. See Request.
+func (r *Client) Delete(resource Path) error {
+
+	err := r.Request(DELETE, resource, nil, nil)
+
+	return err
+}
+
+func buildHTTPClient(httpClient *http.Client) *http.Client {
+	if httpClient != nil {
+		return httpClient
+	}
+	var result = &http.Client{
+		Timeout: time.Second * 10,
+	}
+	return result
+}


### PR DESCRIPTION
This PR adds a check in the assessment process to verify if the SLALite is running on a leader agent. Leader agents on a cluster are the only ones that can read the data written by any agent, and as such, be able to read the ServiceOperationReports, which are the entities needed in the assessment process. The verification is as simple as querying the Policies component if the agent is a leader. More complex verifications could be introduced.

Fixes #19 